### PR TITLE
encoding/protojson: improve marshal performance

### DIFF
--- a/encoding/protojson/bench_test.go
+++ b/encoding/protojson/bench_test.go
@@ -5,11 +5,13 @@
 package protojson_test
 
 import (
+	"google.golang.org/protobuf/types/known/durationpb"
+	"math"
 	"testing"
 
-	"google.golang.org/protobuf/encoding/protojson"
+	pb3 "google.golang.org/protobuf/internal/testprotos/textpb3"
 
-	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func BenchmarkUnmarshal_Duration(b *testing.B) {
@@ -17,6 +19,42 @@ func BenchmarkUnmarshal_Duration(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		err := protojson.Unmarshal(input, &durationpb.Duration{})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+var scalarSample = pb3.Scalars{
+	SBool:     true,
+	SInt32:    math.MaxInt32,
+	SInt64:    math.MaxInt64,
+	SUint64:   math.MaxUint64,
+	SUint32:   2130321213,
+	SSint32:   23132131,
+	SSint64:   3213232123812,
+	SFixed32:  4232943192,
+	SFixed64:  2389182192312,
+	SSfixed32: 281432823,
+	SSfixed64: 23919321921,
+	SFloat:    3213213.2931,
+	SDouble:   39121.321321,
+	SBytes:    []byte("foo_sbytes"),
+	SString:   "foo_sstring",
+}
+
+func BenchmarkMarshal_ScalarsUnordered(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := protojson.MarshalOptions{Unordered: true}.Marshal(&scalarSample)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshal_Scalars(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := protojson.Marshal(&scalarSample)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
it introduces:
- buffered encoder instead of using []byte directly
- pool to recycle buffer
- significant improvement marshaling uint64, int64 (~10alloc/op)
- `MarshalOpts.Unordered` to ignore fields order
- other small improvements

Change-Id: I797dd50a8878ed282c7623da8a5d4899cd468cb3